### PR TITLE
Un-break "build_type" setting detection

### DIFF
--- a/src/build_info/build_settings.rs
+++ b/src/build_info/build_settings.rs
@@ -45,6 +45,12 @@ pub struct BuildSettings {
     pub(crate) os_build: Option<String>,
 }
 
+impl Default for BuildSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BuildSettings {
     pub fn new() -> Self {
         Self {
@@ -70,7 +76,7 @@ impl BuildSettings {
             settings.push(format!("{}={}", "arch_build", arch_build));
         }
 
-        if let Some(build_type) = self.detect_build_type() {
+        if let Some(build_type) = self.build_type.clone().or_else(|| self.detect_build_type()) {
             settings.push(format!("{}={}", "build_type", build_type));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ pub enum BuildPolicy {
 pub struct InstallCommand<'a> {
     profile: Option<&'a str>,
     remote: Option<&'a str>,
-    build_settings: Option<BuildSettings>,
+    build_settings: BuildSettings,
     build_policy: Option<BuildPolicy>,
     recipe_path: Option<PathBuf>,
     output_dir: Option<PathBuf>,
@@ -251,7 +251,7 @@ impl<'a> InstallCommandBuilder<'a> {
         InstallCommand {
             profile: self.profile,
             remote: self.remote,
-            build_settings: self.build_settings,
+            build_settings: self.build_settings.unwrap_or_default(),
             build_policy: self.build_policy,
             recipe_path: self.recipe_path,
             output_dir: self.output_dir,
@@ -304,11 +304,8 @@ impl<'a> InstallCommand<'a> {
             }
         }
 
-        let settings;
-        if let Some(build_settings) = &self.build_settings {
-            settings = build_settings.args();
-            args.extend(settings.iter().map(String::as_str));
-        }
+        let build_settings_args = self.build_settings.args();
+        args.extend(build_settings_args.iter().map(String::as_str));
 
         if let Some(recipe_path) = &self.recipe_path {
             args.push(recipe_path.to_str().unwrap());


### PR DESCRIPTION
Restore the previous (v0.2) behavior where the Conan "build_type" setting value is derived from the "PROFILE" environment variable set by Cargo.

Also fixes the issue where the user-provided "build_type" setting value is silently ignored if "PROFILE" is set.