### PR TITLE
Fix deps include dirs listing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conan"
-version = "0.4.0"
+version = "0.4.1"
 readme = "README.md"
 license = "MIT/Apache-2.0"
 keywords = ["conan", "cmake", "build-dependencies"]

--- a/src/build.rs
+++ b/src/build.rs
@@ -12,6 +12,7 @@ use crate::util::find_program;
 #[derive(Debug, Error)]
 pub enum ConanBuildError {}
 
+/// A command for building a Conan package.
 pub struct BuildCommand {
     recipe_path: Option<PathBuf>,
     build_path: Option<PathBuf>,
@@ -23,6 +24,7 @@ pub struct BuildCommand {
     should_install: bool,
 }
 
+/// Builder pattern for creating a `BuildCommand`
 #[derive(Default)]
 pub struct BuildCommandBuilder {
     recipe_path: Option<PathBuf>,

--- a/src/install.rs
+++ b/src/install.rs
@@ -28,6 +28,7 @@ pub enum ConanInstallError {
     Other(String),
 }
 
+/// Conan build policy
 #[derive(Clone, PartialEq)]
 pub enum BuildPolicy {
     Never,

--- a/src/install/build_info/build_dependency.rs
+++ b/src/install/build_info/build_dependency.rs
@@ -40,6 +40,7 @@ where
     deserializer.deserialize_option(JsonStringOrStringVecVisitor)
 }
 
+/// A build dependency.
 #[derive(Serialize, Deserialize)]
 pub struct BuildDependency {
     pub(crate) version: String,
@@ -72,8 +73,8 @@ impl BuildDependency {
         self.lib_paths.get(0).map(|x| &**x)
     }
 
-    pub fn get_include_dir(&self) -> Option<&str> {
-        self.include_paths.get(0).map(|x| &**x)
+    pub fn get_include_dirs(&self) -> Vec<&str> {
+        self.include_paths.iter().map(|x| &**x).collect()
     }
 
     pub fn get_binary_dir(&self) -> Option<&str> {

--- a/src/install/build_info/build_settings.rs
+++ b/src/install/build_info/build_settings.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use serde::{Deserialize, Serialize};
 
+/// Conan build type
 #[allow(dead_code)]
 #[derive(Clone, PartialEq)]
 pub enum BuildType {
@@ -30,6 +31,7 @@ impl BuildType {
     }
 }
 
+/// Conan build settings
 #[derive(Serialize, Deserialize)]
 pub struct BuildSettings {
     pub(crate) arch: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,8 @@ mod util;
 
 // API
 pub use build::{BuildCommand, BuildCommandBuilder};
-pub use install::{build_info::BuildSettings, BuildPolicy, InstallCommand, InstallCommandBuilder};
-pub use package::{PackageCommand, PackageCommandBuilder, ConanPackage};
+pub use install::{
+    build_info::{BuildDependency, BuildInfo, BuildSettings},
+    BuildPolicy, InstallCommand, InstallCommandBuilder,
+};
+pub use package::{ConanPackage, PackageCommand, PackageCommandBuilder};

--- a/src/package.rs
+++ b/src/package.rs
@@ -32,10 +32,12 @@ pub enum ConanPackageError {
     Other(String),
 }
 
+/// Thin Wrapper around binary packages that contain libraries and headers
 pub struct ConanPackage {
     path: PathBuf,
 }
 
+/// "conan package" command runner
 #[derive(Default)]
 pub struct PackageCommand {
     build_path: Option<PathBuf>,
@@ -57,6 +59,7 @@ impl Default for PackageCommandBuilder {
     }
 }
 
+/// Command arguments builder for "conan package"
 pub struct PackageCommandBuilder {
     build_path: Option<PathBuf>,
     install_path: Option<PathBuf>,


### PR DESCRIPTION
This pull request:

- [x] Fix the `BuildDependency::get_include_dir` returning just the first include dir (some deps have multiple include dirs). I've renamed the method. Fixes #8 .