### PR TITLE
Feat: Add method to generate BuildInfo only if its missing

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -220,10 +220,14 @@ impl<'a> InstallCommand<'a> {
         let program = find_program()?;
         let output_file = self.output_file()?;
         let mut command = Command::new(program);
-        if let Ok(_) = command.args(args).status() {
+        if command.args(args).status().is_ok() {
             BuildInfo::from_file(output_file.as_path())
         } else {
             None
         }
+    }
+
+    pub fn generate_if_no_buildinfo(&self) -> Option<BuildInfo> {
+        BuildInfo::from_file(self.output_file()?.as_path()).or_else(|| self.generate())
     }
 }

--- a/src/install/build_info/test.rs
+++ b/src/install/build_info/test.rs
@@ -8,13 +8,13 @@ fn test_conan_build_info() {
     assert_eq!(openssl.get_binary_dir(), None);
     let openssl_dir = openssl.get_root_dir().unwrap();
     let openssl_lib_dir = openssl.get_library_dir().unwrap();
-    let openssl_inc_dir = openssl.get_include_dir().unwrap();
+    let openssl_inc_dir = openssl.get_include_dirs();
     assert_eq!(
         openssl_dir,
         "/home/awake/.conan/data/openssl/1.1.1b-2/devolutions/stable/package/de9c231f84c85def9df09875e1785a1319fa8cb6"
     );
     assert_eq!(openssl_lib_dir, "/home/awake/.conan/data/openssl/1.1.1b-2/devolutions/stable/package/de9c231f84c85def9df09875e1785a1319fa8cb6/lib");
-    assert_eq!(openssl_inc_dir, "/home/awake/.conan/data/openssl/1.1.1b-2/devolutions/stable/package/de9c231f84c85def9df09875e1785a1319fa8cb6/include");
+    assert_eq!(openssl_inc_dir.first().unwrap().to_owned(), "/home/awake/.conan/data/openssl/1.1.1b-2/devolutions/stable/package/de9c231f84c85def9df09875e1785a1319fa8cb6/include");
 
     let dependencies = build_info.dependencies();
     assert_eq!(dependencies.len(), 1);


### PR DESCRIPTION
This PR adds a `generate_if_no_buildinfo` method to InstallCommand, skipping `conan install` if build info is available, which improves build times a little bit.