### PR TITLE
Feat: Allow rpath configuration

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -196,9 +196,15 @@ impl ConanPackage {
                 }
             }
         }
-
         println!("cargo:rustc-link-search=native={}", libs_dir_path.display());
 
         Ok(())
+    }
+
+    pub fn emit_cargo_rpath_linkage<F>(&self, f: F)
+    where
+        F: Fn(&PathBuf) -> PathBuf,
+    {
+        println!("cargo:rustc-link-arg=-Wl,-rpath={}", f(&self.path).display());
     }
 }


### PR DESCRIPTION
This PR adds a method to `ConanPackage` that allows `rpath` configuration on Unix systems. The interace is left lose as to allow for `$ORIGN`, `@executable_path`, `@loader_path`, `@rpath`.