### PR TITLE
fix: add output folder option to install command

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -189,6 +189,7 @@ impl<'a> InstallCommand<'a> {
             let current_dir = env::current_dir()?.to_path_buf();
             if output_dir != &current_dir {
                 args.extend(&["-if", output_dir.to_str().unwrap()]);
+                args.extend(&["-of", output_dir.to_str().unwrap()]);
             }
         }
 


### PR DESCRIPTION
Command `conan install` allows to specify "The root output folder for generated and build files". This folder is almost always the same as the -if "install folder"